### PR TITLE
feat: add "distinctUntilChanged"

### DIFF
--- a/src/Rxjs.res
+++ b/src/Rxjs.res
@@ -107,6 +107,7 @@ external toObservable: t<'c, 's, 'a> => t<foreign, void, 'a> = "%identity"
 @module("rxjs") external deferPromise: (unit => Js.Promise.t<'a>) => t<foreign, void, 'a> = "defer"
 @module("rxjs") external delayWhen: (unit => t<'c, 's, ()>, . t<'c, 's, 'a>) => t<'c, 's, 'a> = "delayWhen"
 @module("rxjs") external distinct: (unit, . t<'co, 'so, 'a>) => t<'co, 'so, 'a> = "distinct"
+@module("rxjs") external distinctUntilChanged: ((. 'a, 'a) => bool, . t<'co, 'so, 'a>) => t<'co, 'so, 'a> = "distinctUntilChanged"
 
 @module("rxjs") external filter: ('a => bool, . t<'c, 's, 'a>) => t<'c, 's, 'a> = "filter"
 @module("rxjs") external finalize: (() => (), . t<'c, 's, 'a>) => t<'c, 's, 'a> = "finalize"


### PR DESCRIPTION
This adds bindings for [RxJS distinctUntilChanged
](https://rxjs.dev/api/operators/distinctUntilChanged) in the simple form when only the `comparator` parameter is exposed to ReScript and is required.

Splits from #1 