### PR TITLE
refactor!: use @uncurry attribute for callbacks

### DIFF
--- a/src/Rxjs.res
+++ b/src/Rxjs.res
@@ -122,8 +122,8 @@ external toObservable: t<'c, 's, 'a> => t<foreign, void, 'a> = "%identity"
 @module("rxjs") external interval: int => t<foreign, void, int> = "interval"
 @module("rxjs") external last: (unit, . t<'c, 's, 'a>) => t<'c, 's, 'a> = "last"
 @module("rxjs") external lastValueFrom: t<'c, 's, 'a> => Js.Promise.t<'a> = "lastValueFrom"
-@module("rxjs") external map: (. ('a, int) => 'b, . t<'c,'s,'a>) => t<'c, 's, 'b> = "map"
-let const: ('b, . t<'c, 's, 'a>) => t<'c, 's, 'b> = (b) => map(. (_, _) => b)
+@module("rxjs") external map: (@uncurry (('a, int) => 'b), . t<'c,'s,'a>) => t<'c, 's, 'b> = "map"
+let const: ('b, . t<'c, 's, 'a>) => t<'c, 's, 'b> = (b) => map((_, _) => b)
 
 
 @module("rxjs") external merge2: (t<'ca, 'sa, 'a>, t<'cb, 'sb, 'a>) => t<foreign, void, 'a> = "merge"
@@ -153,14 +153,14 @@ type timeinterval<'a> = { interval: int, value: 'a }
 @module("rxjs") external withLatestFrom6: (t<'ca, 'sa, 'a>, t<'cb, 'sb, 'b>, t<'cc, 'sc, 'c>, t<'cd, 'sd, 'd>, t<'ce, 'se, 'e>, t<'cf, 'sf, 'f>, . t<'cz, 'sz, 'z>) => t<'cz, 'sz, ('z, 'a, 'b, 'c, 'd, 'e, 'f)> = "withLatestFrom"
 @module("rxjs") external withLatestFrom7: (t<'ca, 'sa, 'a>, t<'cb, 'sb, 'b>, t<'cc, 'sc, 'c>, t<'cd, 'sd, 'd>, t<'ce, 'se, 'e>, t<'cf, 'sf, 'f>, t<'cg, 'sg, 'g>, . t<'cz, 'sz, 'z>) => t<'cz, 'sz, ('z, 'a, 'b, 'c, 'd, 'e, 'f, 'g)> = "withLatestFrom"
 
-let keepMap: ( 'a => option<'b>, . t<'ca, 'sa, 'a>) => t<'ca, 'sa, 'b> = (f, . xs) => {
+let keepMap: ('a => option<'b>, . t<'ca, 'sa, 'a>) => t<'ca, 'sa, 'b> = (f, . xs) => {
   xs->pipe3(
-    map(. (a, _) => f(a)),
-    filter( x => switch x {
+    map((a, _) => f(a)),
+    filter(x => switch x {
       | Some(_) => true
       | None => false
     }),
-    map(. (a, _) => {
+    map((a, _) => {
       switch a {
         | Some(a) => a
         | None => Js.Exn.raiseError("Rxjs keepMap asserted that an element should exist")


### PR DESCRIPTION
This uses the `@uncurry` ReScript attribute on callbacks to simplify usage. From the docs

> In general, uncurry is recommended; the compiler will do lots of optimizations to resolve the currying to uncurrying at compile time. However, there are some cases the compiler can't optimize it. In these cases, it will be converted to a runtime check.
> -- https://rescript-lang.org/docs/manual/latest/bind-to-js-function#extra-solution

I read the long thread [uncurried by default](https://forum.rescript-lang.org/t/uncurried-by-default/274/1) and I see Uncurried functions in [ReScript v11 roadmap](https://rescript-lang.org/community/roadmap), but I don't know if these relate? Does it mean the ReScript v11 will be uncurried by default? If so, we might close this PR as it presents a breaking change and wait for the new ReScript version.

Splits from #1 